### PR TITLE
Integrate Docker packaging with GitHub Actions

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -1,0 +1,31 @@
+name: Build and Package as Docker Container
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Build with Maven
+      run: mvn clean install
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: user/appname:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use an official Java runtime as a parent image
+FROM openjdk:11-jre-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the jar file into the container
+COPY target/BoletoJava-0.0.1-SNAPSHOT.jar /app/BoletoJava.jar
+
+# Make port 8080 available to the world outside this container
+EXPOSE 8080
+
+# Run the jar file
+CMD ["java", "-jar", "BoletoJava.jar"]

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,13 @@
 2. Execute `java -jar BoletoJava-0.0.1-SNAPSHOT.jar` para iniciar a aplicação.
 3. A aplicação estará disponível em `http://localhost:8080`.
 
+### Como construir e executar usando Docker
+
+1. Certifique-se de que o Docker esteja instalado em sua máquina.
+2. Construa a imagem Docker executando `docker build -t boletojava .` na raiz do projeto.
+3. Execute a aplicação usando `docker run -p 8080:8080 boletojava`.
+4. A aplicação estará disponível em `http://localhost:8080`.
+
 ## API Endpoints
 
 A aplicação suporta as seguintes operações CRUD através de APIs RESTful:


### PR DESCRIPTION
Related to #3

This pull request introduces the necessary configurations for compiling and packaging the BoletoJava application as a Docker container, as well as updates the documentation to reflect these new capabilities.

- **Adds a Dockerfile**: The newly added `Dockerfile` specifies the Java 11 runtime as the base image, sets the working directory, copies the built JAR file into the container, exposes port 8080, and defines the command to run the application.
- **Updates the README.md**: Instructions for building and running the application using Docker have been added, providing users with the steps to build the Docker image and run the application within a Docker container.
- **Introduces GitHub Actions Workflow**: A new GitHub Actions workflow file, `maven-package.yml`, has been added to automate the process of building the Maven project and packaging it as a Docker container. This workflow triggers on push and pull request events to the main branch, sets up JDK 11, builds the project with Maven, and then builds and pushes the Docker image.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/felipementel/BoletoJava/issues/3?shareId=9cc9b5d5-4de1-45d6-97f2-fe94425ec944).